### PR TITLE
Add table whitelist to pgloader configuration

### DIFF
--- a/pgloader.conf
+++ b/pgloader.conf
@@ -14,6 +14,30 @@ LOAD DATABASE
     maintenance_work_mem to '128MB',
     work_mem to '12MB'
 
+  INCLUDING ONLY TABLE NAMES MATCHING
+    ~/^agreements_/,
+    ~/^ask_cfpb_/,
+    ~/^auth_/,
+    ~/^data_research_/,
+    'django_admin_log',
+    'django_content_type',
+    'django_migrations',
+    'django_session',
+    'django_site',
+    ~/^flags_/,
+    ~/^jobmanager_/,
+    'post_preview_cache',
+    ~/^taggit_/,
+    ~/^v1_/,
+    ~/^wagtail/,
+    ~/^paying_for_college_/,
+    ~/^countylimits_/,
+    ~/^ratechecker_/,
+    ~/^regcore_/,
+    ~/^retirement_api_/,
+    ~/^hud_api_replace_/,
+    ~/^comparisontool_/
+
   BEFORE LOAD DO
   $$ CREATE SCHEMA IF NOT EXISTS cfgov; $$
 ;


### PR DESCRIPTION
This change sets up a table whitelist for pgloader, so that only certain data is copied across from MySQL to PostgreSQL. This list includes all tables currently active in [cfgov-refresh](https://github.com/cfpb/cfgov-refresh) and its satellite apps.

See platform#2611 for further details.

@richaagarwal I should move this repo into the CFPB organization, but in the meantime can I please tag you for a review?