### PR TITLE
Use Postgres 10.3 instead of Postgres 9.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Migrating the [consumerfinance.gov](https://www.consumerfinance.gov) website fro
 
 ## How to use this repository
 
-This repository consists of a [Docker Compose](https://docs.docker.com/compose/) setup that runs the [pgloader](https://pgloader.io/) tool to convert data from a MySQL 5.1 dump file to PostgreSQL 9.6 dump file.
+This repository consists of a [Docker Compose](https://docs.docker.com/compose/) setup that runs the [pgloader](https://pgloader.io/) tool to convert data from a MySQL 5.1 dump file to PostgreSQL 10.3 dump file.
 
 If using docker-machine, create a Docker machine with suitable memory:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./:/host:ro
   postgres:
-    image: postgres:9.6 
+    image: postgres:10.3
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
This change bumps the version of the Postgres DB used in the conversion process from 9.6 to 10.3.

To confirm, after running the conversion process, check the dump:

```sh
$ gzcat postgres.sql.gz | grep "version 10.3"
-- Dumped from database version 10.3 (Debian 10.3-1.pgdg90+1)
-- Dumped by pg_dump version 10.3 (Debian 10.3-1.pgdg90+1)
```