### PR TITLE
Add -c option to clean in Postgres dump

### DIFF
--- a/postgres_dump.sh
+++ b/postgres_dump.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-PGPASSWORD=cfgov pg_dump -U cfgov cfgov | gzip > /host/postgres.sql.gz
+PGPASSWORD=cfgov pg_dump -c -U cfgov cfgov | gzip > /host/postgres.sql.gz


### PR DESCRIPTION
This change modifies how the [`pg_dump`](https://www.postgresql.org/docs/10/static/app-pgdump.html) command is called by this project to dump out the converted database data. We want the dump to include the various `DROP` statements so that it deletes and recreates existing tables instead of just loading the new data into existing ones.