### PR TITLE
Use a schema of cfpb, not cfgov

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ To load the dumped data back into a local Postgres:
 ```sh
 $ dropdb cfgov
 $ createdb cfgov
-$ createuser cfgov
-$ gunzip < postgres.sql.gz | psql cfgov
+$ createuser cfpb
+$ gunzip < postgres.sql.gz | psql postgres://cfpb@localhost/cfgov
 ```
 
 ### Using a local MySQL volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     ports:
       - "3306:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: cfgov
-      MYSQL_DATABASE: cfgov
-      MYSQL_USER: cfgov
-      MYSQL_PASSWORD: cfgov
+      MYSQL_ROOT_PASSWORD: cfpb
+      MYSQL_DATABASE: cfpb
+      MYSQL_USER: cfpb
+      MYSQL_PASSWORD: cfpb
     volumes:
       - ./:/host:ro
   postgres:
@@ -17,9 +17,9 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_DB: cfgov
-      POSTGRES_USER: cfgov
-      POSTGRES_PASSWORD: cfgov
+      POSTGRES_DB: cfpb
+      POSTGRES_USER: cfpb
+      POSTGRES_PASSWORD: cfpb
     volumes:
       - ./:/host
   pgloader:

--- a/mysql_load.sh
+++ b/mysql_load.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-zcat /host/mysql.sql.gz | mysql -u root --password=cfgov cfgov
+zcat /host/mysql.sql.gz | mysql -u root --password=cfpb cfpb

--- a/pgloader.conf
+++ b/pgloader.conf
@@ -1,6 +1,6 @@
 LOAD DATABASE
-  FROM mysql://cfgov:cfgov@mysql/cfgov
-  INTO postgresql://cfgov:cfgov@postgres/cfgov
+  FROM mysql://cfpb:cfpb@mysql/cfpb
+  INTO postgresql://cfpb:cfpb@postgres/cfpb
 
   WITH
     include drop,
@@ -39,5 +39,5 @@ LOAD DATABASE
     ~/^comparisontool_/
 
   BEFORE LOAD DO
-  $$ CREATE SCHEMA IF NOT EXISTS cfgov; $$
+  $$ CREATE SCHEMA IF NOT EXISTS cfpb; $$
 ;

--- a/postgres_dump.sh
+++ b/postgres_dump.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-PGPASSWORD=cfgov pg_dump -c -U cfgov cfgov | gzip > /host/postgres.sql.gz
+PGPASSWORD=cfpb pg_dump -c -U cfpb cfpb | gzip > /host/postgres.sql.gz


### PR DESCRIPTION
This change modifies the Postgres dump generated by this code so that it uses a schema of `cfpb`, not `cfgov`. This will make it easier to use in environments where we have a username of `cfpb`.