### PR TITLE
Generate simpler, more reliable Postgres dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ $ ./convert.sh
 To load the dumped data back into a local Postgres:
 
 ```sh
-$ dropdb cfgov
-$ createdb cfgov
-$ createuser cfpb
+$ dropdb --if-exists cfgov && dropuser --if-exists cfpb
+$ createuser cfpb && createdb -O cfpb cfgov
 $ gunzip < postgres.sql.gz | psql postgres://cfpb@localhost/cfgov
 ```
+
+The generated Postgres dump will include a `CREATE SCHEMA cfpb` command and so the database user must have permission to execute this command. If the database is created with `createdb -O cfpb`, the `cfpb` user will be an owner and will have sufficient permission to do so.
 
 ### Using a local MySQL volume
 

--- a/postgres_dump.sh
+++ b/postgres_dump.sh
@@ -1,3 +1,19 @@
 #!/usr/bin/env bash
 
-PGPASSWORD=cfpb pg_dump -c -U cfpb cfpb | gzip > /host/postgres.sql.gz
+# Dumps contents of Postgres database to file. Uses these options:
+#
+# --clean: Drops existing objects before loading them.
+# --if-exists: Uses IF EXISTS statements when dropping objects.
+# --no-owner: Don't retain existing object ownership.
+# --no-privileges: Don't include privilege statements from database.
+# --schema=cfpb: Only dump cfpb schema (exclude public).
+# --user=cfpb: Connect to database as cfpb user.
+PGPASSWORD=cfpb pg_dump \
+    --clean \
+    --if-exists \
+    --no-owner \
+    --no-privileges \
+    --schema=cfpb \
+    --user=cfpb \
+    cfpb \
+    | gzip > /host/postgres.sql.gz


### PR DESCRIPTION
This change modifies the `pg_dump` command used to generate the Postgres dump that is the final output of this conversion. It sets a few flags on `pg_dump` to limit the data that gets put in the output dump.

Specifically, the dump now does:

`--clean`: Drops existing objects before loading them.
`--if-exists`: Uses IF EXISTS statements when dropping objects.
`--no-owner`: Don't retain existing object ownership.
`--no-privileges`: Don't include privilege statements from database.
`--schema=cfpb`: Only dump `cfpb` schema (exclude `public`).

This makes the dumps more reliable and easier to load into various databases. For example, previously when loading into an empty database, the lack of `IF EXISTS` would generate a (harmless) error to stderr on various `DROP` commands. This not only clutters the output but makes it harder to depend on the existence of stderr as a way to tell if a subsequent load worked properly.

To confirm that this dump works locally, follow the new instructions in the README:

```sh
$ dropdb --if-exists cfgov && dropuser --if-exists cfpb
$ createuser cfpb && createdb -O cfpb cfgov
$ gunzip < postgres.sql.gz | psql postgres://cfpb@localhost/cfgov
```

This database works when running against [cfgov-refresh](https://github.com/cfpb/cfgov-refresh) locally, with `DATABASE_URL=postgres://cfpb@localhost/cfgov`. It can also be loaded using the cfgov-refresh `./refresh-data.sh` script.

When running cfgov-refresh in Docker, this dump can be loaded in the Docker shell using `./refresh-data.sh`, and works properly, assuming that the changes from https://github.com/cfpb/cfgov-refresh/pull/4081 are included to use a Postgres username of `cfpb`.

I can also confirm that this dump can be loaded into one of the cf.gov Postgres databases in AWS RDS, using our Postgres Ansible playbook.

Note that the cfpb user must be an owner of the cfgov database in order to execute the necessary `CREATE SCHEMA cfpb` command. The README has been updated to document this fact.