### PR TITLE
Remove django-hud table

### DIFF
--- a/pgloader.conf
+++ b/pgloader.conf
@@ -35,7 +35,6 @@ LOAD DATABASE
     ~/^ratechecker_/,
     ~/^regcore_/,
     ~/^retirement_api_/,
-    ~/^hud_api_replace_/,
     ~/^comparisontool_/
 
   BEFORE LOAD DO


### PR DESCRIPTION
We are officially deprecating use of [django-hud](https://github.com/cfpb/django-hud) (see GHE platform issue 2719).  