### PR TITLE
Add regulations3k to the list of migrated tables

### DIFF
--- a/pgloader.conf
+++ b/pgloader.conf
@@ -34,6 +34,7 @@ LOAD DATABASE
     ~/^countylimits_/,
     ~/^ratechecker_/,
     ~/^regcore_/,
+    ~/^regulations3k_/,
     ~/^retirement_api_/,
     ~/^comparisontool_/
 


### PR DESCRIPTION
As of https://github.com/cfpb/cfgov-refresh/pull/4060, the new regulations3k app includes some models. This change adds those models to the list of tables included in this migration.

@higs4281