### PR TITLE
Add TDP to the list of apps to be converted

### DIFF
--- a/pgloader.conf
+++ b/pgloader.conf
@@ -36,7 +36,8 @@ LOAD DATABASE
     ~/^regcore_/,
     ~/^regulations3k_/,
     ~/^retirement_api_/,
-    ~/^comparisontool_/
+    ~/^comparisontool_/,
+    ~/^teachers_digital_platform_/
 
   BEFORE LOAD DO
   $$ CREATE SCHEMA IF NOT EXISTS cfpb; $$


### PR DESCRIPTION
The cfgov-refresh satellite app [teachers_digital_platform](https://github.com/cfpb/teachers-digital-platform) doesn't have any Django models [yet](https://github.com/cfpb/teachers-digital-platform/blob/master/teachers_digital_platform/models.py), but may soon. In an attempt to be forward looking, this change adds TDP to the list of tables that are converted from MySQL to Postgres by this project. If no tables exist, this change won't make any difference. If some are added, they will be converted.

If some tables were to be added without this change, they wouldn't be included in Postgres converted dumps, and thus could cause problems downstream.

FYI @acrewdson @schbetsy -- I can't add you as a reviewer due to GH groups.